### PR TITLE
Optimize make_shared using allocate_shared

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,16 +216,6 @@ proc                 : {...} [Type: std::shared_ptr<jxy::ProcessContext>]
 ```
 
 ## TODO
-Although `jxy::shared_ptr` is supported through `std::shared_ptr` directly. 
-This implementation could be improved. Internally, `std::shared_ptr` will use a 
-global `new` allocation in some circumstances. To avoid this `jxy::make_shared` 
-is implemented to associate the appropriate pool tagged/typed allocator and 
-deleter. This introduces an extra control block allocation for the shared 
-reference, which is what `std::make_shared` aims to avoid. Unfortunately, 
-attaching a control block to the container is not public functionality. This 
-could be improved with some support by MSVC or by hand-rolling a 
-`jxy::shared_ptr` which is better tuned for kernel-use.
-
 I had wanted to include `std::unordered_map` initially, however it uses `ceilf`.
 Floating point arithmetic in the Windows Kernel comes with some challenges. 
 So, for now it is omitted until an appropriate solution is designed.


### PR DESCRIPTION
This PR updates `jxy::make_shared` to force use of `std::allocate_shared`. Since `std::make_shared` provides no way to specify the allocator, the old implementation would cause an extra allocation for the control block since it would allocate the object and construct the `jxy::shared_ptr` with it (which internally must allocate the control block using the specified allocator). This now is avoided with `std::allocate_shared` 🎉!

Thanks grandpa (you know who you are 😉) for brining `std::allocate_shared` to my attention!